### PR TITLE
Add support for controlling request queue size in squid

### DIFF
--- a/src/SquidConfig.h
+++ b/src/SquidConfig.h
@@ -535,7 +535,7 @@ public:
         int v4_first;       ///< Place IPv4 first in the order of DNS results.
         ssize_t packet_max; ///< maximum size EDNS advertised for DNS replies.
     } dns;
-
+    int redirector_queue_threshold;
 };
 
 extern SquidConfig Config;

--- a/src/cf.data.pre
+++ b/src/cf.data.pre
@@ -5134,6 +5134,16 @@ DOC_START
 	be allowed to request.
 DOC_END
 
+NAME: url_rewrite_queue_threshold
+TYPE: int
+LOC: Config.redirector_queue_threshold
+DEFAULT: 5
+DOC_START
+	This is the number of total requests queued across all redirectors
+    before a request will bypass the redirector.
+DOC_END
+
+
 NAME: url_rewrite_extras
 TYPE: TokenOrQuotedString
 LOC: Config.redirector_extras

--- a/src/helper.cc
+++ b/src/helper.cc
@@ -27,6 +27,7 @@
 #include "SquidTime.h"
 #include "Store.h"
 #include "wordlist.h"
+#include "SquidConfig.h"
 
 #define HELPER_MAX_ARGS 64
 
@@ -468,6 +469,8 @@ helperStats(StoreEntry * sentry, helper * hlp, const char *label)
                       hlp->stats.queue_size);
     storeAppendPrintf(sentry, "avg service time: %d msec\n",
                       hlp->stats.avg_svc_time);
+    storeAppendPrintf(sentry, "Max request length hit: %d requests\n",
+                      hlp->stats.max_queue_size);
     storeAppendPrintf(sentry, "\n");
     storeAppendPrintf(sentry, "%7s\t%7s\t%7s\t%11s\t%11s\t%s\t%7s\t%7s\t%7s\n",
                       "ID #",
@@ -1086,10 +1089,11 @@ Enqueue(helper * hlp, Helper::Request * r)
     hlp->last_queue_warn = squid_curtime;
 
     debugs(84, DBG_CRITICAL, "WARNING: All " << hlp->childs.n_active << "/" << hlp->childs.n_max << " " << hlp->id_name << " processes are busy.");
-    debugs(84, DBG_CRITICAL, "WARNING: " << hlp->stats.queue_size << " pending requests queued");
+    debugs(84, DBG_CRITICAL, "WARNING: " << hlp->stats.queue_size << " pending requests queued. Max allowed: " << Config.redirector_queue_threshold );
     debugs(84, DBG_CRITICAL, "WARNING: Consider increasing the number of " << hlp->id_name << " processes in your config file.");
 
-    if (hlp->stats.queue_size > (int)hlp->childs.n_running * 2)
+ // if (hlp->stats.queue_size > (int)hlp->childs.n_running * 2)
+    if (hlp->stats.queue_size > Config.redirector_queue_threshold)
         fatalf("Too many queued %s requests", hlp->id_name);
 }
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -51,6 +51,7 @@ public:
         int replies;
         int queue_size;
         int avg_svc_time;
+        int max_queue_size;
     } stats;
 
 private:


### PR DESCRIPTION
There is a need to bypass URL filtering in case the load is
high, but the option to bypass it kicks in even if one request
is queued. Modify this to take in a configurable value to control
the queue size

This option will be like this squid.conf

url_rewrite_queue_threshold 10


Re #9816